### PR TITLE
ci: route releases through pull requests

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -5,7 +5,8 @@ frontend, and Python Movie Concierge. Production infrastructure is reconciled fr
 
 ## Continuous integration
 
-Every branch push runs separate jobs for:
+Every pull request targeting `master`, every merged `master` commit, and a deliberate manual run
+starts separate jobs for:
 
 - Java 25 backend build, tests, integration tests, JaCoCo, compiler checks, and dependency safety.
 - React client generation, linting, tests, strict TypeScript, and production build.
@@ -30,19 +31,26 @@ opt-in and never receive credentials in ordinary CI.
 4. Resolve immutable image digests.
 5. Update only `backend.yaml`, `frontend.yaml`, and `agent.yaml` in the home-cluster GitOps tree.
 6. Strictly verify that all three manifests use the requested release version and immutable digest.
-7. Commit the digest update and create the annotated release tag.
-8. Let Argo CD reconcile the cluster from Git.
+7. Commit the digest update to `release/v<VERSION>-deployment` and create the annotated release tag.
+8. Open a deployment pull request instead of pushing directly to protected `master`.
+9. Approve the bot-created PR's CI run, review the three digest changes, and merge it.
+10. Let Argo CD reconcile the cluster from the merged Git state.
 
-Feature-branch CI permits manifests to keep referencing the last released digests while `VERSION`
+Pull-request CI permits manifests to keep referencing the last released digests while `VERSION`
 prepares the next release. The strict version match is enabled only inside CD after the new images
 exist, preventing Argo CD from attempting to pull a not-yet-published tag.
+
+The repository must allow GitHub Actions to create pull requests under **Settings → Actions →
+General → Workflow permissions**. Pull-request CI created with the repository `GITHUB_TOKEN` needs
+one manual approval from a user with write access. No personal access token or protected-branch
+bypass is required.
 
 Provider and MCP credentials are not available to GitHub Actions. The agent build and deterministic
 verification path requires neither an OpenAI key nor a running Java service.
 
 Infrastructure-only changes under `infrastructure/clusters/home` do not require a `VERSION` bump or
-new application images. After normal CI and review, a merge to `master` lets Argo CD reconcile those
-manifests directly.
+new application images. After pull-request CI and review, a merge to `master` lets Argo CD reconcile
+those manifests directly.
 
 Movie seed images are independent data releases. Their Argo CD Application has automated sync
 disabled, so normal releases never reseed PostgreSQL or RustFS.

--- a/.github/workflows/continuous-deployment.yaml
+++ b/.github/workflows/continuous-deployment.yaml
@@ -10,6 +10,11 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
+
+concurrency:
+  group: versioned-app-release
+  cancel-in-progress: false
 
 jobs:
   release-app:
@@ -30,13 +35,21 @@ jobs:
             echo "VERSION must be semver without leading v, got: $version" >&2
             exit 1
           fi
-          echo "value=$version" >> "$GITHUB_OUTPUT"
-          echo "tag=v$version" >> "$GITHUB_OUTPUT"
+          {
+            echo "value=$version"
+            echo "tag=v$version"
+            echo "branch=release/v${version}-deployment"
+          } >> "$GITHUB_OUTPUT"
 
-      - name: Ensure release tag does not exist
+      - name: Ensure release refs do not exist
         run: |
           if git rev-parse --verify --quiet "refs/tags/${{ steps.version.outputs.tag }}" >/dev/null; then
             echo "Release tag ${{ steps.version.outputs.tag }} already exists" >&2
+            exit 1
+          fi
+          if git ls-remote --exit-code --heads origin \
+            "refs/heads/${{ steps.version.outputs.branch }}" >/dev/null; then
+            echo "Release branch ${{ steps.version.outputs.branch }} already exists" >&2
             exit 1
           fi
 
@@ -165,17 +178,20 @@ jobs:
       - name: Validate rendered Kubernetes schemas
         run: make verify-kubernetes-schema
 
-      - name: Commit manifest update
+      - name: Commit deployment manifest update
+        env:
+          RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
         run: |
           if git diff --quiet infrastructure/clusters/home/apps/backend.yaml infrastructure/clusters/home/apps/frontend.yaml infrastructure/clusters/home/apps/agent.yaml; then
-            echo "Manifests already point at ${{ steps.version.outputs.tag }}"
-            exit 0
+            echo "No deployment manifest changes for ${{ steps.version.outputs.tag }}" >&2
+            exit 1
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$RELEASE_BRANCH"
           git add infrastructure/clusters/home/apps/backend.yaml infrastructure/clusters/home/apps/frontend.yaml infrastructure/clusters/home/apps/agent.yaml
-          git commit -m "chore(release): update app image digests [skip ci]"
-          git push
+          git commit -m "chore(release): deploy ${{ steps.version.outputs.tag }} image digests"
+          git push --set-upstream origin "$RELEASE_BRANCH"
 
       - name: Create release tag
         run: |
@@ -184,3 +200,33 @@ jobs:
           git tag -a "${{ steps.version.outputs.tag }}" "${{ github.sha }}" \
             -m "Release ${{ steps.version.outputs.tag }}"
           git push origin "${{ steps.version.outputs.tag }}"
+
+      - name: Create deployment pull request
+        id: deployment-pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_BRANCH: ${{ steps.version.outputs.branch }}
+          RELEASE_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          body="$(printf '%s\n' \
+            "## Deployment" \
+            "" \
+            "Deploys the immutable backend, frontend, and Movie Concierge images published as ${RELEASE_TAG}." \
+            "" \
+            "The release workflow verified all three image versions and Kubernetes production contracts before opening this pull request." \
+            "Merging it lets Argo CD reconcile the production cluster from Git." \
+            "" \
+            "This pull request was created by the versioned app release workflow.")"
+          pr_url="$(gh pr create \
+            --base master \
+            --head "$RELEASE_BRANCH" \
+            --title "chore(release): deploy ${RELEASE_TAG}" \
+            --body "$body")"
+          echo "url=$pr_url" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Deployment pull request"
+            echo
+            echo "$pr_url"
+            echo
+            echo "Approve its CI run, review the three digest changes, and merge it to deploy through Argo CD."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,8 +1,12 @@
 name: CI - Build / Test Deployables
 
 on:
+  pull_request:
+    branches:
+      - master
   push:
-    branches: ['*']
+    branches:
+      - master
   workflow_dispatch:
 
 permissions:

--- a/Makefile
+++ b/Makefile
@@ -300,7 +300,10 @@ container-smoke-agent: ## smoke-test the Python agent image, endpoints, and non-
 
 ##@ Verification
 
-.PHONY: verify-kubernetes-render verify-seed-release verify-kubernetes-schema verify-movie-concierge-production verify-observability-production verify-observability-charts verify-openapi-drift
+.PHONY: verify-release-workflows verify-kubernetes-render verify-seed-release verify-kubernetes-schema verify-movie-concierge-production verify-observability-production verify-observability-charts verify-openapi-drift
+
+verify-release-workflows: ## verify protected-branch CI and release PR contracts
+	ruby infrastructure/clusters/home/tests/verify_release_workflows.rb
 
 verify-kubernetes-render: check-kubernetes-verification-tools ## render home-cluster Kubernetes manifests
 	kubectl kustomize infrastructure/clusters/home/apps > $(K8S_RENDER_OUTPUT)
@@ -310,7 +313,7 @@ verify-seed-release: verify-kubernetes-render ## verify normal releases cannot r
 	ruby infrastructure/clusters/home/tests/verify_seed_release.rb \
 		$(K8S_RENDER_OUTPUT) $(K8S_SEED_RENDER_OUTPUT)
 
-verify-kubernetes-schema: verify-seed-release verify-movie-concierge-production verify-observability-production ## validate rendered Kubernetes manifests with pinned kubeconform
+verify-kubernetes-schema: verify-release-workflows verify-seed-release verify-movie-concierge-production verify-observability-production ## validate rendered Kubernetes manifests with pinned kubeconform
 	ruby -ryaml -e 'ARGV.each { |path| YAML.load_stream(File.read(path)).each { |doc| next if doc.nil?; doc.delete("sops") if doc.is_a?(Hash); puts YAML.dump(doc) } }' \
 		$(K8S_RENDER_OUTPUT) $(K8S_SEED_RENDER_OUTPUT) > $(K8S_SCHEMA_OUTPUT)
 	docker run --rm -i $(KUBECONFORM_IMAGE) \

--- a/README.md
+++ b/README.md
@@ -359,19 +359,20 @@ environment-specific server URL, so contract drift fails before client generatio
 
 ## Release And Deployment
 
-Every push runs backend verification plus frontend client generation, linting, tests, type checking, and a production
-build. Application releases are controlled by the root [`VERSION`](./VERSION) file. A version bump on `master` also
-triggers the CD workflow, which:
+Every pull request targeting `master` runs backend verification plus frontend client generation, linting, tests, type
+checking, and a production build. The same gates run again on merged `master` commits. Application releases are
+controlled by the root [`VERSION`](./VERSION) file. A version bump merged to `master` triggers the CD workflow, which:
 
 1. runs backend, frontend, and deterministic agent checks,
 2. builds Linux AMD64 backend, frontend, and agent Docker images,
 3. pushes versioned images to Docker Hub,
 4. resolves immutable image digests,
-5. updates the home-cluster Kubernetes manifests,
-6. lets Argo CD reconcile the live cluster from Git.
+5. updates the home-cluster Kubernetes manifests on a dedicated release branch,
+6. opens a deployment pull request containing the three immutable image digests,
+7. lets Argo CD reconcile the live cluster only after that pull request passes CI and is merged.
 
-Infrastructure-only changes under `infrastructure/clusters/home` can be deployed through a normal push to `master`
-without publishing new application images.
+Infrastructure-only changes under `infrastructure/clusters/home` can be deployed through a normal reviewed pull
+request without publishing new application images.
 
 ## Project Structure
 

--- a/docs/superpowers/specs/2026-05-18-version-gated-app-release-pipeline-design.md
+++ b/docs/superpowers/specs/2026-05-18-version-gated-app-release-pipeline-design.md
@@ -6,17 +6,17 @@ The home cluster is deployed through Argo CD from
 `infrastructure/clusters/home/apps`. Infrastructure manifest changes should be
 deployed by normal GitOps sync after they land on `master`.
 
-Backend and frontend app images should not be rebuilt and deployed for every
-code-only push. They should move only when the project app version changes.
+Backend, frontend, and Movie Concierge images should not be rebuilt and
+deployed for every code-only pull request. They should move only when the
+project app version changes.
 
 ## Version Source
 
 Add one root-level `VERSION` file as the source of truth for the app release
 version.
 
-Backend and frontend share that version because the frontend depends on the
-backend OpenAPI contract and the deployment should move as one coherent app
-release.
+Backend, frontend, and Movie Concierge share that version because their
+contracts and deployment should move as one coherent app release.
 
 Seed images remain separate for now because they are large and data-driven.
 
@@ -27,10 +27,12 @@ only when `VERSION` changed in the pushed commit range.
 
 Normal outcomes:
 
-- Code-only push: CI runs, no app images are published.
-- Infrastructure manifest push: CI runs, Argo CD applies the manifest change.
-- `VERSION` bump: CI runs, backend/frontend images are built and pushed, k3s
-  manifests are updated to the new image digests, then Argo CD deploys.
+- Code-only pull request: CI runs, no app images are published.
+- Infrastructure manifest pull request: CI runs; after merge, Argo CD applies
+  the manifest change.
+- `VERSION` bump: pull-request CI runs; after merge, backend/frontend images are
+  built and pushed and a second pull request proposes the new k3s image digests.
+  Argo CD deploys only after that deployment pull request is merged.
 
 ## Image Tags
 
@@ -38,6 +40,7 @@ For version `0.2.2`, publish:
 
 - `niklastiede/imdb-clone-backend:v0.2.2`
 - `niklastiede/imdb-clone-frontend:v0.2.2`
+- `niklastiede/imdb-clone-agent:v0.2.2`
 
 The workflow may also update `latest`, but GitOps manifests must pin the
 version tag plus digest.
@@ -48,6 +51,7 @@ After pushing images, the workflow resolves image digests and updates:
 
 - `infrastructure/clusters/home/apps/backend.yaml`
 - `infrastructure/clusters/home/apps/frontend.yaml`
+- `infrastructure/clusters/home/apps/agent.yaml`
 
 The resulting image references use:
 
@@ -55,8 +59,11 @@ The resulting image references use:
 repository:v<version>@sha256:<digest>
 ```
 
-The workflow commits the manifest update back to `master`. The commit should be
-marked so it does not recursively trigger a second release build.
+The workflow commits the manifest update to a deterministic
+`release/v<VERSION>-deployment` branch and opens a pull request targeting
+protected `master`. The deployment commit must run CI; it must not use a skip-CI
+marker or a protected-branch bypass. Merging this pull request does not trigger
+a second release build because it does not change `VERSION`.
 
 ## Verification
 
@@ -65,6 +72,7 @@ checks as normal CI:
 
 - Backend build/tests.
 - Frontend dependency install and build.
+- Movie Concierge checks and deterministic evals.
 - Docker buildx setup and Docker Hub login.
 
 E2E remains manual for now.

--- a/infrastructure/clusters/home/tests/verify_movie_concierge.rb
+++ b/infrastructure/clusters/home/tests/verify_movie_concierge.rb
@@ -228,17 +228,4 @@ dashboard = JSON.parse(dashboard_manifest.dig("data", "agent-overview.json"))
 assert_contract(dashboard["uid"] == "imdb-agent-overview", "agent dashboard UID drifted")
 assert_contract(dashboard.fetch("panels").length >= 10, "agent dashboard is incomplete")
 
-workflow = File.read(File.join(repository_root, ".github/workflows/continuous-deployment.yaml"))
-%w[make\ verify-agent imdb-clone-agent APP_VERSION agent.yaml].each do |contract|
-  assert_contract(workflow.include?(contract.tr("\\", "")), "CD agent contract is missing #{contract}")
-end
-assert_contract(
-  workflow.include?("APP_VERSION=${{ steps.version.outputs.value }}"),
-  "agent build metadata must use the unprefixed release version"
-)
-assert_contract(
-  workflow.include?("EXPECTED_APP_VERSION: ${{ steps.version.outputs.value }}"),
-  "CD must strictly verify every released image version"
-)
-
 puts "Movie Concierge production manifest contracts passed."

--- a/infrastructure/clusters/home/tests/verify_release_workflows.rb
+++ b/infrastructure/clusters/home/tests/verify_release_workflows.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+repository_root = File.expand_path("../../../..", __dir__)
+ci = File.read(File.join(repository_root, ".github/workflows/continuous-integration.yaml"))
+release = File.read(File.join(repository_root, ".github/workflows/continuous-deployment.yaml"))
+
+def assert_contract(condition, message)
+  raise message unless condition
+end
+
+assert_contract(
+  ci.match?(/on:\n  pull_request:\n    branches:\n      - master\n  push:\n    branches:\n      - master\n/),
+  "CI must verify pull requests and merged master commits"
+)
+%w[backend-build-test frontend-build-test agent-build-test infrastructure-validate].each do |job|
+  assert_contract(ci.match?(/^  #{Regexp.escape(job)}:$/), "CI is missing required job #{job}")
+end
+
+assert_contract(release.include?("contents: write"), "release requires contents write permission")
+assert_contract(
+  release.include?("pull-requests: write"),
+  "release requires pull-request write permission"
+)
+assert_contract(
+  release.include?("group: versioned-app-release") &&
+    release.include?("cancel-in-progress: false"),
+  "releases must be serialized without cancellation"
+)
+assert_contract(
+  release.include?('branch=release/v${version}-deployment'),
+  "release must create a version-specific deployment branch"
+)
+%w[make\ verify-agent imdb-clone-agent APP_VERSION agent.yaml].each do |contract|
+  assert_contract(
+    release.include?(contract.tr("\\", "")),
+    "release agent contract is missing #{contract}"
+  )
+end
+assert_contract(
+  release.include?("APP_VERSION=${{ steps.version.outputs.value }}"),
+  "agent build metadata must use the unprefixed release version"
+)
+assert_contract(
+  release.include?("EXPECTED_APP_VERSION: ${{ steps.version.outputs.value }}"),
+  "release must strictly verify every published image version"
+)
+assert_contract(
+  release.include?('git push --set-upstream origin "$RELEASE_BRANCH"'),
+  "release must push manifests to a deployment branch"
+)
+assert_contract(
+  release.include?("gh pr create") &&
+    release.include?("--base master") &&
+    release.include?('--head "$RELEASE_BRANCH"'),
+  "release must open a deployment pull request"
+)
+push_commands = release.lines.grep(/\bgit push\b/).map(&:strip)
+expected_push_commands = [
+  'git push --set-upstream origin "$RELEASE_BRANCH"',
+  'git push origin "${{ steps.version.outputs.tag }}"'
+]
+assert_contract(
+  push_commands.sort == expected_push_commands.sort,
+  "release may push only its deployment branch and annotated tag"
+)
+assert_contract(!release.include?("[skip ci]"), "deployment commits must run pull-request CI")
+
+tag_step = release.index("- name: Create release tag")
+pull_request_step = release.index("- name: Create deployment pull request")
+assert_contract(!tag_step.nil? && !pull_request_step.nil?, "release completion steps are missing")
+assert_contract(
+  tag_step < pull_request_step,
+  "release tag must exist before the deployment pull request is offered"
+)
+
+puts "Protected-branch release workflow contracts passed."

--- a/infrastructure/kubernetes/README.md
+++ b/infrastructure/kubernetes/README.md
@@ -224,16 +224,19 @@ make verify-movie-concierge-production
 make verify-kubernetes-schema
 ```
 
-Do not use `kubectl apply` for a release. An intentional shared `VERSION` change on `master` starts
-the version-gated workflow, which tests and publishes backend, frontend, and agent images, resolves
-immutable digests, and commits the three GitOps image updates for Argo CD. Infrastructure-only
-changes do not rebuild application images; after CI and review, Argo CD reconciles their merged
-manifests directly from Git.
+Do not use `kubectl apply` for a release. An intentional shared `VERSION` change merged to `master`
+starts the version-gated workflow, which tests and publishes backend, frontend, and agent images,
+resolves immutable digests, and opens a deployment pull request with the three GitOps image updates.
+After its CI run is approved and the digest changes are reviewed, merging the pull request lets Argo
+CD reconcile production. Infrastructure-only changes do not rebuild application images; after
+pull-request CI and review, Argo CD reconciles their merged manifests directly from Git.
 
 During release preparation, the manifests deliberately remain pinned to the last published image
-digests. Branch CI validates those immutable references without requiring them to match the pending
-`VERSION`. After building the new images, CD enables strict `EXPECTED_APP_VERSION` validation and
-updates all three manifests atomically. This avoids a temporary reference to an unpublished image.
+digests. Pull-request CI validates those immutable references without requiring them to match the
+pending `VERSION`. After building the new images, CD enables strict `EXPECTED_APP_VERSION` validation and
+updates all three manifests atomically on `release/v<VERSION>-deployment`. This avoids a temporary
+reference to an unpublished image and prevents the release workflow from bypassing protected
+`master`.
 
 Argo CD is exposed for home LAN access at
 `https://argocd.imdb-clone.the-coding-lab.com`. The route is intended for


### PR DESCRIPTION
## Summary

- run deployable CI for pull requests targeting `master`
- publish release digests on a dedicated deployment branch
- open a reviewed deployment pull request instead of pushing directly to protected `master`
- enforce the workflow contract in the Kubernetes verification gate
- document the protected-branch release flow

## Verification

- `actionlint .github/workflows/continuous-integration.yaml .github/workflows/continuous-deployment.yaml`
- `make verify-release-workflows`
- `make verify-kubernetes-schema`
- `make verify-observability-charts`

## Activation

Merge this pull request before activating the prepared `master` ruleset. Also enable **Allow GitHub Actions to create and approve pull requests** under repository Actions settings before the next versioned release.