### PR TITLE
fix(k8s): curb logs and CPU throttling

### DIFF
--- a/infrastructure/clusters/home/apps/postgresql.yaml
+++ b/infrastructure/clusters/home/apps/postgresql.yaml
@@ -29,6 +29,17 @@ spec:
           persistence:
             enabled: true
             size: 10Gi
+          # Preserve the scheduling guarantee while allowing short database bursts.
+          # A 150m CFS ceiling throttled PostgreSQL despite low average CPU usage.
+          resourcesPreset: none
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+              ephemeral-storage: 50Mi
+            limits:
+              memory: 192Mi
+              ephemeral-storage: 2Gi
           service:
             type: ClusterIP
             ports:

--- a/infrastructure/clusters/home/apps/rustfs.yaml
+++ b/infrastructure/clusters/home/apps/rustfs.yaml
@@ -28,7 +28,13 @@ spec:
             address: ":9000"
             console_enable: "true"
             console_address: ":9001"
+            log_level: "warn"
             region: "us-east-1"
+        # Chart 0.3.0 does not checksum its ConfigMap into the pod template.
+        # Keep this explicit override so the log-level change rolls the pod.
+        extraEnv:
+          - name: RUSTFS_OBS_LOGGER_LEVEL
+            value: "warn"
         service:
           type: ClusterIP
           endpoint:

--- a/infrastructure/clusters/home/tests/verify_observability.rb
+++ b/infrastructure/clusters/home/tests/verify_observability.rb
@@ -218,10 +218,50 @@ assert_contract(
 )
 
 rustfs = resource(documents, "Application", "rustfs", "argocd")
+rustfs_values = rustfs.dig("spec", "source", "helm", "valuesObject")
 assert_contract(
-  rustfs.dig("spec", "source", "helm", "valuesObject", "config", "rustfs", "console_enable") ==
-    "true",
+  rustfs_values.dig("config", "rustfs", "console_enable") == "true",
   "RustFS console must be enabled for private tunnel access"
+)
+assert_contract(
+  rustfs_values.dig("config", "rustfs", "log_level") == "warn",
+  "RustFS must suppress info-level scanner noise at the source"
+)
+assert_contract(
+  rustfs_values["extraEnv"] == [
+    {
+      "name" => "RUSTFS_OBS_LOGGER_LEVEL",
+      "value" => "warn"
+    }
+  ],
+  "RustFS log-level changes must alter the pod template until the chart adds ConfigMap checksums"
+)
+
+postgresql = resource(documents, "Application", "postgresql", "argocd")
+postgresql_primary = postgresql.dig(
+  "spec",
+  "source",
+  "helm",
+  "valuesObject",
+  "primary"
+)
+assert_contract(
+  postgresql_primary["resourcesPreset"] == "none",
+  "PostgreSQL must not inherit the throttling-prone nano CPU limit"
+)
+assert_contract(
+  postgresql_primary["resources"] == {
+    "requests" => {
+      "cpu" => "100m",
+      "memory" => "128Mi",
+      "ephemeral-storage" => "50Mi"
+    },
+    "limits" => {
+      "memory" => "192Mi",
+      "ephemeral-storage" => "2Gi"
+    }
+  },
+  "PostgreSQL must keep resource guarantees without a CFS CPU ceiling"
 )
 
 public_ingresses = documents.select { |document| document["kind"] == "Ingress" }


### PR DESCRIPTION
Run RustFS at warn and pin the level in the pod template because chart 0.3.0 does not roll ConfigMap-only changes.

Keep PostgreSQL's CPU request and memory bounds, but remove the 150m CFS ceiling so short bursts can use idle node capacity.